### PR TITLE
Configure EdgeX specific Jenkins minion scripts

### DIFF
--- a/jenkins-scripts/README
+++ b/jenkins-scripts/README
@@ -1,0 +1,8 @@
+The scripts in this directory are used by the Jenkins spin-up component
+for dynamic minions.
+
+The spinup script will be as follows (${system_type} will be replaced
+with the appropriate system_type script)
+
+git clone https://github.com/edgexfoundry/ci-management.git /ci-management
+/ci-management/jenkins-scripts/jenkins-init-script.sh

--- a/jenkins-scripts/basic_settings.sh
+++ b/jenkins-scripts/basic_settings.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# @License EPL-1.0 <http://spdx.org/licenses/EPL-1.0>
+##############################################################################
+# Copyright (c) 2016 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+
+case "$(facter operatingsystem)" in
+  Ubuntu)
+    apt-get update
+    ;;
+  *)
+    # Do nothing on other distros for now
+    ;;
+esac
+
+IPADDR=$(facter ipaddress)
+HOSTNAME=$(facter hostname)
+FQDN=$(facter fqdn)
+
+echo "${IPADDR} ${HOSTNAME} ${FQDN}" >> /etc/hosts
+
+#Increase limits
+cat <<EOF > /etc/security/limits.d/jenkins.conf
+jenkins         soft    nofile          16000
+jenkins         hard    nofile          16000
+EOF
+
+cat <<EOSSH >> /etc/ssh/ssh_config
+Host *
+  ServerAliveInterval 60
+
+# we don't want to do SSH host key checking on spin-up systems
+Host 10.30.122.*
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+EOSSH
+
+cat <<EOKNOWN >  /etc/ssh/ssh_known_hosts
+github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+EOKNOWN
+
+# vim: sw=2 ts=2 sts=2 et :

--- a/jenkins-scripts/create_jenkins_user.sh
+++ b/jenkins-scripts/create_jenkins_user.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# @License EPL-1.0 <http://spdx.org/licenses/EPL-1.0>
+##############################################################################
+# Copyright (c) 2016 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+
+#######################
+# Create Jenkins User #
+#######################
+
+OS=$(facter operatingsystem | tr '[:upper:]' '[:lower:]')
+
+useradd -m -s /bin/bash jenkins
+
+# Check if docker group exists
+grep -q docker /etc/group
+if [ "$?" == '0' ]
+then
+  # Add jenkins user to docker group
+  usermod -a -G docker jenkins
+fi
+
+# Check if mock group exists
+grep -q mock /etc/group
+if [ "$?" == '0' ]
+then
+  # Add jenkins user to mock group so they can build Int/Pack's RPMs
+  usermod -a -G mock jenkins
+fi
+
+mkdir /home/jenkins/.ssh
+mkdir /w
+cp -r /home/${OS}/.ssh/authorized_keys /home/jenkins/.ssh/authorized_keys
+# Generate ssh key for use by Robot jobs
+echo -e 'y\n' | ssh-keygen -N "" -f /home/jenkins/.ssh/id_rsa -t rsa
+chown -R jenkins:jenkins /home/jenkins/.ssh /w

--- a/jenkins-scripts/jenkins-init-script.sh
+++ b/jenkins-scripts/jenkins-init-script.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# @License EPL-1.0 <http://spdx.org/licenses/EPL-1.0>
+##############################################################################
+# Copyright (c) 2016 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+
+# vim: ts=4 sw=4 sts=4 et :
+
+cd /ci-management/jenkins-scripts
+chmod +x ./*.sh
+./system_type.sh
+
+source /tmp/system_type.sh
+./basic_settings.sh
+if [ -f "${SYSTEM_TYPE}.sh" ]
+then
+    ./"${SYSTEM_TYPE}.sh"
+fi
+
+# Create the jenkins user last so that hopefully we don't have to deal with
+# guard files
+./create_jenkins_user.sh

--- a/jenkins-scripts/system_type.sh
+++ b/jenkins-scripts/system_type.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# @License EPL-1.0 <http://spdx.org/licenses/EPL-1.0>
+##############################################################################
+# Copyright (c) 2016 The Linux Foundation and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+##############################################################################
+
+HOST=$(/bin/hostname)
+SYSTEM_TYPE=''
+
+IFS=','
+for i in "basebuild,basebuild" \
+         "centos,centos" \
+         "trusty,trusty" \
+         "xenial,xenial"
+do set -- $i
+    if [[ $HOST == *"$1"* ]]; then
+        SYSTEM_TYPE="$2"
+        break
+    fi
+done
+
+# Write out the system type to an environment file to then be sourced
+echo "SYSTEM_TYPE=${SYSTEM_TYPE}" > /tmp/system_type.sh
+
+# vim: sw=4 ts=4 sts=4 et :


### PR DESCRIPTION
Our build minions need start scripts for when they care coming online.
While we were initially starting the project we leveraged the start
scripts of a different project that The Linux Foundation supports. It's
best if each of the projects are using scripts that are more customized
to their needs.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>